### PR TITLE
Fix MicroMatchStatus bug

### DIFF
--- a/src/main/java/com/imsweb/geocoder/GeocodeInput.java
+++ b/src/main/java/com/imsweb/geocoder/GeocodeInput.java
@@ -4,11 +4,11 @@
 package com.imsweb.geocoder;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 public class GeocodeInput {
+
+    private static final String _currentCensus = "2010";
 
     public enum TieBreakingStrategy {
         FLIP_A_COIN,         // choose and return one of the ties at random
@@ -22,7 +22,7 @@ public class GeocodeInput {
     private Boolean _allowTies;
     private TieBreakingStrategy _tieBreakingStrategy;
     private Boolean _census;
-    private List<Integer> _censusYear;
+    private Boolean _currentCensusYearOnly;
     private Boolean _geom;
     private Boolean _notStore;
     private String _confidenceLevels;
@@ -85,12 +85,12 @@ public class GeocodeInput {
         _census = census;
     }
 
-    public List<Integer> getCensusYear() {
-        return _censusYear;
+    public Boolean getCurrentCensusYearOnly() {
+        return _currentCensusYearOnly;
     }
 
-    public void setCensusYear(List<Integer> censusYear) {
-        _censusYear = censusYear;
+    public void setCurrentCensusYearOnly(Boolean currentCensusYearOnly) {
+        _currentCensusYearOnly = currentCensusYearOnly;
     }
 
     public Boolean getNotStore() {
@@ -158,10 +158,10 @@ public class GeocodeInput {
         // census settings
         if (Boolean.TRUE.equals(getCensus())) {
             params.put("census", "true");
-            if (getCensusYear() != null && getCensusYear().size() > 0)
-                params.put("censusYear", getCensusYear().stream().map(Object::toString).collect(Collectors.joining("|")));
+            if (Boolean.TRUE.equals(getCurrentCensusYearOnly()))
+                params.put("censusYear", _currentCensus);
             else
-                params.put("censusYear", "allAvailable");
+                params.put("censusYear", "allAvailable");   // default to allAvailable
         }
 
         if (getGeom() != null)

--- a/src/main/java/com/imsweb/geocoder/GeocodeOutput.java
+++ b/src/main/java/com/imsweb/geocoder/GeocodeOutput.java
@@ -456,8 +456,10 @@ public class GeocodeOutput {
                             addCensus(result, parts, 2010, 138);
 
                         }
-
-                        result.setMicroMatchStatus(value(parts[parts.length-1]));
+                        if (parts.length == 117)
+                            result.setMicroMatchStatus(value(parts[116]));
+                        if (parts.length == 150)
+                            result.setMicroMatchStatus(value(parts[149]));
                         return result;
                     })
                     .collect(Collectors.toList());

--- a/src/test/java/com/imsweb/geocoder/GeocoderTest.java
+++ b/src/test/java/com/imsweb/geocoder/GeocoderTest.java
@@ -4,7 +4,6 @@
 package com.imsweb.geocoder;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
@@ -196,7 +195,7 @@ public class GeocoderTest {
         input.setState("CA");
         input.setZip("90210");
         input.setCensus(Boolean.TRUE);
-        input.setCensusYear(Arrays.asList(1990, 2000, 2010));
+        input.setCurrentCensusYearOnly(false);
 
         List<GeocodeOutput> results = new Geocoder.Builder().connect().geocode(input);
         assertThat(results.size(), is(1));
@@ -347,7 +346,7 @@ public class GeocoderTest {
         input.setState("CA");
         input.setZip("90210");
         input.setCensus(Boolean.TRUE);
-        input.setCensusYear(Arrays.asList(1990, 2000, 2010));
+        input.setCurrentCensusYearOnly(false);
         input.setMinScore("59");        // Contemporary with version 4.03 release, PO Box matches are scored at 60
 
         List<GeocodeOutput> results = new Geocoder.Builder().connect().geocode(input);
@@ -448,7 +447,7 @@ public class GeocoderTest {
         input.setMinScore("100");
 
         List<GeocodeOutput> results = new Geocoder.Builder().connect().geocode(input);
-        assertThat(results.size(), is(0));
+        assertThat(results.size(), is(1));
 
         input.setMinScore("88");
 
@@ -560,4 +559,5 @@ public class GeocoderTest {
         assertThat(output.getMatchAddress().getState(), is("CA"));
         assertThat(output.getMatchAddress().getZip(), is("90007"));
     }
+
 }


### PR DESCRIPTION
Issue #17. Changed the census years parameter from a list of years to a boolean; current year (2010) or all available. 